### PR TITLE
Fixes Middle Click Pasting in Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,10 +88,18 @@ export default {
 
 	windowMouseDown(e) {
 		if (this.scrolling) {
+			var homeObject = this;
+			
+			//Slight delay added as otherwise it will paste on the second middle-click
+			setTimeout(function() {
+				atom.clipboard.write(homeObject.clipboard_backup);
+			}, 100);
 			this.stopScroll();
 		} else {
 			let editor;
 			if (e.button === 1 && (editor = e.target.closest("atom-text-editor:not([mini])")) && this.editor !== editor) {
+				this.clipboard_backup = atom.clipboard.read();
+				atom.clipboard.write('');
 				this.startScroll(editor, e);
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -87,19 +87,22 @@ export default {
 	},
 
 	windowMouseDown(e) {
-		if (this.scrolling) {
+		if(e.button === 1 && typeof this.clipboard_backup === "undefined") {
+			this.clipboard_backup = atom.clipboard.read();
+			atom.clipboard.write("");
 			var homeObject = this;
 			
-			//Slight delay added as otherwise it will paste on the second middle-click
 			setTimeout(function() {
 				atom.clipboard.write(homeObject.clipboard_backup);
+				homeObject.clipboard_backup = undefined;
 			}, 100);
+		}
+	
+		if (this.scrolling) {
 			this.stopScroll();
 		} else {
 			let editor;
 			if (e.button === 1 && (editor = e.target.closest("atom-text-editor:not([mini])")) && this.editor !== editor) {
-				this.clipboard_backup = atom.clipboard.read();
-				atom.clipboard.write('');
 				this.startScroll(editor, e);
 			}
 		}


### PR DESCRIPTION
Backs up and restores the contents of the clipboard when middle click is pressed. This seems to fix the issue for me.

Only real issue I could imagine this causing is someone middle-clicking Atom with something important in the clipboard then leaving Atom open without ever restoring it. I would have added this as an optional setting "fix middle-click pasting" but I am not familiar enough with extending Atom.