### PR TITLE
stopPropagation on start/stopScroll mousedown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,53 @@
 <!-- lint disable first-heading-level list-item-indent -->
-## 0.5.0 - [ESC] cancels scrolling
+
+## [0.6.0](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.6.0) (2018-04-08)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.5.0...v0.6.0)
+
+- Prevent cursor moving on middle click
+- Prevent paste on middle click in linux
+
+## [0.5.0](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.5.0) (2018-04-06)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.4.0...v0.5.0)
+
 - Press <kbd>ESC</kbd> to cancel scrolling
 
-## 0.4.0 - Remove Hold Button setting
+## [0.4.0](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.4.0) (2017-11-07)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.3.1...v0.4.0)
+
 - Click or Hold works at the same time
 
-## 0.3.1 - Fix hold on middle button
+## [0.3.1](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.3.1) (2017-11-07)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.3.0...v0.3.1)
+
 - Fix hold on middle button
 
-## 0.3.0 - Add setting to hold down button instead of click
+## [0.3.0](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.3.0) (2017-11-06)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.2.0...v0.3.0)
+
 - Add Hold Button setting
 - Set cursor on all elements
 
-## 0.2.0 - Add cursor images and threshold
+## [0.2.0](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.2.0) (2017-11-03)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.1.1...v0.2.0)
+
 - Show images for cursor when scrolling
 - Add threshold option to allow straighter scrolling
 
-## 0.1.1 - Style dot
+## [0.1.1](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.1.1) (2017-11-03)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/v0.1.0...v0.1.1)
+
 - Set your own styles on dot with class .scroll-editor-on-middle-click-dot
 - Cancel on any button clicked
 
-## 0.1.0 - First Release
+## [0.1.0](https://github.com/UziTech/atom-scroll-editor-on-middle-click/releases/tag/v0.1.0) (2017-11-03)
+
+[Full Changelog](https://github.com/UziTech/atom-scroll-editor-on-middle-click/compare/76a7f103ef9d166088c549e80f09b6695871b0f3...v0.1.0)
+
 - Initial Release

--- a/index.js
+++ b/index.js
@@ -77,21 +77,16 @@ export default {
 		this.currentY = e.pageY;
 	},
 
-	windowClick(e) {
-		let editor;
-		if (e.button === 1 && (editor = e.target.closest("atom-text-editor:not([mini])")) && this.editor !== editor) {
-			this.startScroll(editor, e);
-		} else if (this.editor) {
-			this.stopScroll();
-		}
-	},
-
 	windowMouseDown(e) {
 		if (this.scrolling) {
+			if (e.button === 1) {
+				e.stopPropagation();
+			}
 			this.stopScroll();
 		} else {
 			let editor;
 			if (e.button === 1 && (editor = e.target.closest("atom-text-editor:not([mini])")) && this.editor !== editor) {
+				e.stopPropagation();
 				this.startScroll(editor, e);
 			}
 		}
@@ -121,7 +116,6 @@ export default {
 		this.disposables = new CompositeDisposable();
 
 		this.setCurrent = this.setCurrent.bind(this);
-		this.windowClick = this.windowClick.bind(this);
 		this.windowMouseDown = this.windowMouseDown.bind(this);
 		this.windowMouseUp = this.windowMouseUp.bind(this);
 		this.scrollEditor = this.scrollEditor.bind(this);


### PR DESCRIPTION
Use `stopPropagation` on `mouseDown` when `startScroll` or `stopScroll` are called.

This prevents the cursor from moving on middle click.

fixes #5 
closes #6